### PR TITLE
Convert to use openbao, update to 1.19

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # htconfig-vault
-This package configures a [Hashicorp Vault](https://vaultproject.io/) server
+This package configures an [OpenBao](https://openbao.org) server
 for use with [htgettoken](https://github.com/fermitools/htgettoken).
 Users of htgettoken always have to initially authenticate with OIDC,
 but after that access can be renewed with either kerberos or ssh.
 
-In addition to making it easy to configure the server, this package includes
-a modified Hashicorp vault plugin
-([vault-plugin-auth-jwt](https://github.com/hashicorp/vault-plugin-auth-jwt)),
-a vault plugin from Puppet Labs
-([vault-plugin-secrets-oauthapp](https://github.com/puppetlabs/vault-plugin-secrets-oauthapp)),
-and another vault plugin from an individual
-([vault-plugin-auth-ssh](https://github.com/42wim/vault-plugin-auth-ssh)).
+In addition to making it easy to configure the server, this package includes an
+([oauth secrets plugin](https://github.com/openbao/openbao-plugin-secrets-oauthapp))
+and a
+([ssh authentication plugin](https://github.com/42wim/vault-plugin-auth-ssh)).
+
+OpenBao is a fully open source fork of
+[Hashicorp Vault](https://vaultproject.io) so that is the history of
+the name of this package.
+The server is still often referred to as a Vault server including on this page.
+Unlike the Vault project, the OpenBao project has accepted our
+modifications so we we can use the builtin jwt/oidc "plugin."
 
 ## Mailing list
 

--- a/libexec/parseconfig.py
+++ b/libexec/parseconfig.py
@@ -92,7 +92,11 @@ for f in files:
         continue
     try:
         with open(f) as fd:
-            data = yaml.load(fd)
+            try:
+                # newer yaml version needs extra parameter
+                data = yaml.load(fd, Loader=yaml.FullLoader)
+            except:
+                data = yaml.load(fd)
     except Exception as e:
         efatal('error loading yaml in ' + f, e)
                  

--- a/make-source-tarball
+++ b/make-source-tarball
@@ -2,7 +2,7 @@
 
 # use $TMPDIR as temporary space for improved performance
 
-for N in 1 2 3; do
+for N in 1 2; do
     for V in plugin${N}_name plugin${N}_version; do
         eval "`sed -n "s/^%define $V /$V=/p" rpm/htvault-config.spec`"
     done
@@ -41,25 +41,15 @@ export GOPATH=$PWD/gopath
 go install github.com/mitchellh/gox@v$gox_version
 rm -f $GOPATH/bin/gox
 
-curl -s https://codeload.github.com/hashicorp/${plugin1_name}/tar.gz/${plugin1_prefix}${plugin1_version} | tar xzf -
+curl -s https://codeload.github.com/42wim/${plugin1_name}/tar.gz/${plugin1_prefix}${plugin1_version} | tar xzf -
 cd ${plugin1_name}-${plugin1_version}
-curl -sL https://github.com/hashicorp/$plugin1_name/pull/119.diff | patch -p1
-curl -sL https://github.com/hashicorp/$plugin1_name/pull/131.diff | patch -p1
-make bootstrap
 go mod vendor
 cd ..
 
-curl -s https://codeload.github.com/42wim/${plugin2_name}/tar.gz/${plugin2_prefix}${plugin2_version} | tar xzf -
+curl -s https://codeload.github.com/openbao/${plugin2_name}/tar.gz/${plugin2_prefix}${plugin2_version} | tar xzf -
 cd ${plugin2_name}-${plugin2_version}
 go mod vendor
-cd ..
-
-curl -s https://codeload.github.com/puppetlabs/${plugin3_name}/tar.gz/${plugin3_prefix}${plugin3_version} | tar xzf -
-cd ${plugin3_name}-${plugin3_version}
-curl -sL https://github.com/puppetlabs/$plugin3_name/pull/41.diff | patch -p1
-curl -sL https://github.com/puppetlabs/$plugin3_name/pull/90.diff | patch -p1
 make generate
-go mod vendor
 cd ..
 cd ..
 rm -rf $GOPATH/pkg/mod/cache/vcs

--- a/misc/config.service
+++ b/misc/config.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=Vault configuration
+Description=HTVault configuration
 Requires=vault.service
 After=vault.service
 PartOf=vault.service

--- a/misc/sysconfig
+++ b/misc/sysconfig
@@ -1,8 +1,8 @@
 # Sets the maximum number of CPUs that can be executing Go threads simultaneously
 #GOMAXPROCS=0
 
-# Additional options to pass to Vault service binary
+# Additional options to pass to service binary
 #VAULT_SERVICE_OPTIONS=""
 
-# To enable debugging in main vault:
+# To enable debugging in main server:
 #VAULT_SERVICE_OPTIONS="-log-level=trace"

--- a/misc/systemd.conf
+++ b/misc/systemd.conf
@@ -3,7 +3,7 @@ EnvironmentFile=/etc/sysconfig/htvault-config
 PermissionsStartOnly=true
 ExecStartPre=/usr/libexec/htvault-config/preconfig.sh
 ExecStart=
-ExecStart=/usr/bin/vault server $VAULT_SERVICE_OPTIONS -config=/var/lib/htvault-config/vault.hcl
+ExecStart=/usr/bin/bao server $VAULT_SERVICE_OPTIONS -config=/var/lib/htvault-config/vault.hcl
 # This is needed to allow the audit log to be moved anywhere without
 #  dynamically modifying the systemd config and restarting the service
 ProtectHome=no


### PR DESCRIPTION
- Replace vault with openbao-2.2.0 and remove vault-plugin-secrets-jwt (since the builtin version works with openbao).
- Replace vault-plugin-secrets-oauthapp with openbao-plugin-secrets-oauthapp 3.2.0 but still install it as vault-plugins-secrets-oauthapp for upgrade compatibility.
- Update vault-plugin-auth-ssh to 0.3.4.