### PR TITLE
Stop trying to use disable_mlock

### DIFF
--- a/libexec/vault.common.template
+++ b/libexec/vault.common.template
@@ -3,10 +3,6 @@
  */
 
 plugin_directory = "/usr/libexec/htvault-config/plugins"
-# The docs say to use setcap on vault and plugins instead of 
-#  disable_mlock in production
-# https://www.vaultproject.io/docs/configuration/#inlinecode-disable_mlock
-disable_mlock = true
 ui = true
 
 listener "tcp" {

--- a/rpm/htvault-config.spec
+++ b/rpm/htvault-config.spec
@@ -120,6 +120,9 @@ systemctl daemon-reload
 %attr(750, openbao,root) %dir %{_localstatedir}/log/%{name}
 
 %changelog
+# - Delete the "disable_mlock" configuration option in vault.hcl because
+#   openbao does not support it.
+
 * Thu Apr 09 2026 Dave Dykstra <dwd@fnal.gov> 2.3.0-1
 - Add `noconfirm` callbackmode.
 - Update minimum required openbao to 2.5.2.


### PR DESCRIPTION
It is a deprecated option on openbao and prints a warning.