### PR TITLE
Fix rate limiting configuration when cluster leader is not master

### DIFF
--- a/libexec/config.sh
+++ b/libexec/config.sh
@@ -171,7 +171,7 @@ for RATELIMIT in $_old_ratelimits; do
         # and there's no way to disable it only for localhost
         echo "Temporarily disabling $RATELIMIT rate limit"
     fi
-    curl -sS -H "$ROOTTOKEN" -X DELETE $VAULT_ADDR/v1/sys/quotas/rate-limit/"$RATELIMIT"
+    echo "$ROOTTOKEN" | curl -sSL -H @- -X DELETE $VAULT_ADDR/v1/sys/quotas/rate-limit/"$RATELIMIT"
 done
 ENBLEDMODS=""
 updateenabledmods()
@@ -682,7 +682,7 @@ for RATELIMIT in $_ratelimits; do
     else
         echo "Restoring $RATELIMIT rate limit"
     fi
-    curl -sS -H "$ROOTTOKEN" -X POST -d @- $VAULT_ADDR/v1/sys/quotas/rate-limit/"$RATELIMIT" <<EOF
+    echo "$ROOTTOKEN" | curl -sSL -H @- -X POST -d @/dev/fd/3 $VAULT_ADDR/v1/sys/quotas/rate-limit/"$RATELIMIT" 3<<EOF
     {
         "path" : "$path",
         "rate" : "$rate",

--- a/rpm/htvault-config.spec
+++ b/rpm/htvault-config.spec
@@ -120,6 +120,8 @@ systemctl daemon-reload
 %attr(750, openbao,root) %dir %{_localstatedir}/log/%{name}
 
 %changelog
+# - Fix rate limiting configuration to work in a cluster when the leader is
+#   not the first machine (that is, the master)
 # - Delete the "disable_mlock" configuration option in vault.hcl because
 #   openbao does not support it.
 


### PR DESCRIPTION
The curl commands configuring rate limiting needed to have `-L` in case there is redirect from the master machine in a cluster (which is always the first one) to another one that's the current leader.

In addition, this change keeps the root vault token out of `ps` for those commands.